### PR TITLE
🎨 UI調整

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -4,6 +4,7 @@ import TodoItem from '@/components/todo-item';
 import { TodosProvider, useTodos } from '@/contexts/todos-context';
 import { useState } from 'react';
 import { StyleSheet, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
 export default function ListScreen() {
   return (
@@ -22,11 +23,11 @@ function ListScreenBody() {
 
   return (
     <View style={styles.container}>
-      <View style={styles.buttonContainer}>
-        <IconButton iconName="add" onPress={() => {setTaskInputModalVisible(true);}} />
-      </View>
       <View style={styles.listContainer}>
         <TodoList />
+      </View>
+      <View style={styles.buttonContainer}>
+        <IconButton iconName='add' onPress={() => {setTaskInputModalVisible(true);}} />
       </View>
       <TaskInputModal isVisible={isTaskInputModalVisible} onClose={onTaskInputModalClose} />
     </View>
@@ -37,11 +38,11 @@ function TodoList() {
   const {todos} = useTodos();
 
   return (
-    <View>
+    <SafeAreaView>
       {todos.map(todo => (
         <TodoItem key={todo.id} todo={todo} />
       ))}
-    </View>
+    </SafeAreaView>
   )
 }
 
@@ -51,12 +52,14 @@ const styles = StyleSheet.create({
   },
   buttonContainer: {
     flex: 1,
-    marginRight: 24,
-    marginBottom: 24,
+    position: 'absolute',
+    right: 24,
+    bottom: 24,
     alignItems: 'flex-end',
     justifyContent: 'flex-end'
   },
   listContainer: {
+    marginVertical: 8,
     marginHorizontal: 16,
   }
 })

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -3,7 +3,7 @@ import TaskInputModal from '@/components/task-input-modal';
 import TodoItem from '@/components/todo-item';
 import { TodosProvider, useTodos } from '@/contexts/todos-context';
 import { useState } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { ScrollView, StyleSheet, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 export default function ListScreen() {
@@ -38,10 +38,15 @@ function TodoList() {
   const {todos} = useTodos();
 
   return (
-    <SafeAreaView>
-      {todos.map(todo => (
-        <TodoItem key={todo.id} todo={todo} />
-      ))}
+    <SafeAreaView style={styles.todoListSafeArea}>
+      <ScrollView
+        contentContainerStyle={styles.todoListContent}
+        showsVerticalScrollIndicator={false}
+      >
+        {todos.map(todo => (
+          <TodoItem key={todo.id} todo={todo} />
+        ))}
+      </ScrollView>
     </SafeAreaView>
   )
 }
@@ -59,7 +64,14 @@ const styles = StyleSheet.create({
     justifyContent: 'flex-end'
   },
   listContainer: {
+    flex: 1,
     marginVertical: 8,
     marginHorizontal: 16,
-  }
+  },
+  todoListSafeArea: {
+    flex: 1,
+  },
+  todoListContent: {
+    paddingBottom: 96,
+  },
 })

--- a/components/icon-button.tsx
+++ b/components/icon-button.tsx
@@ -1,5 +1,6 @@
 import { Ionicons } from "@expo/vector-icons";
 import { Pressable, StyleSheet, useColorScheme, View } from "react-native";
+import { red } from "react-native-reanimated/lib/typescript/Colors";
 
 type IconButtonProps = {
   iconName: keyof typeof Ionicons.glyphMap;
@@ -9,9 +10,10 @@ type IconButtonProps = {
 export default function IconButton({ iconName, onPress }: IconButtonProps) {
   const colorScheme = useColorScheme();
   const iconColor = colorScheme === 'dark' ? '#FFFFFF' : '#000000';
+  const backgroundColor = colorScheme === 'dark' ? '#000000' : '#FFFFFF';
 
   return (
-    <View style={[styles.iconButtonContainer, { borderColor: iconColor }]}>
+    <View style={[styles.iconButtonContainer, { borderColor: iconColor , backgroundColor: backgroundColor}]}>
       <Pressable
         style={styles.iconButton}
         onPress={onPress}

--- a/components/todo-item.tsx
+++ b/components/todo-item.tsx
@@ -1,4 +1,4 @@
-import { Pressable, StyleSheet, Text, View } from "react-native"
+import { Pressable, StyleSheet, Text, useColorScheme, View } from "react-native"
 import {Checkbox} from 'expo-checkbox'
 import { Todo } from "@/types/todo"
 import { useTodos } from "@/contexts/todos-context";
@@ -8,12 +8,15 @@ type TodoItemProps = {
 }
 
 export default function TodoItem({todo}: TodoItemProps) {
+  const colorScheme = useColorScheme();
+  const textColor = colorScheme === 'dark' ? '#FFFFFF' : '#000000';
+  const borderColor = colorScheme === 'dark' ? '#FFFFFF' : '#000000';
   const {toggleTodo} = useTodos();
 
   return (
     <Pressable onPress={() => toggleTodo(todo.id)}>
-      <View style={styles.container}>
-        <Text>{todo.title}</Text>
+      <View style={[styles.container, {borderBottomColor: borderColor}]}>
+        <Text style={{color: textColor}}>{todo.title}</Text>
         <Checkbox value={todo.isCompleted} />
       </View>
     </Pressable>
@@ -22,8 +25,10 @@ export default function TodoItem({todo}: TodoItemProps) {
 
 const styles = StyleSheet.create({
   container: {
+    height: 48,
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'space-between',
+    borderBottomWidth: 1,
   }
 })


### PR DESCRIPTION
# 概要

アプリUIを調整する

# 変更点

- 追加ボタンを画面右下に固定
- Todo アイテムのUIを調整
  - 高さを設定
  - ダークモード時にテキストが見えるように、colorScheme に合わせたテキスト色を設定
- Todo リストをスクロールできるようにした



変更前  
<img width="30%" height="959" alt="スクリーンショット 2026-05-06 19 19 07" src="https://github.com/user-attachments/assets/20bfb545-4074-4c17-ba67-da8164d5ab40" />

変更後  
<img width="30%" height="954" alt="スクリーンショット 2026-05-06 19 18 02" src="https://github.com/user-attachments/assets/0336f8c9-7316-4eb4-adcc-b9c9b217e107" />




# 動作確認

- [x] アプリが起動できる
- [x] Todo リストがスクロールできる